### PR TITLE
Ability to specify alignment of menu relative to trigger

### DIFF
--- a/dropit.js
+++ b/dropit.js
@@ -43,9 +43,7 @@
                     
                     // Close if outside click
                     $(document).on('click', function(){
-                        settings.beforeHide.call(this);
-                        $('.dropit-open').removeClass('dropit-open').find('.dropit-submenu').hide();
-                        settings.afterHide.call(this);
+                        hide_menu(el, settings);
                     });
                     
                     settings.afterLoad.call(this);


### PR DESCRIPTION
Hi,

This has two main changes:
- you can specify the alignment of the menu relative to the trigger:
  
  $('#rightmenu').dropit({ align: 'right' });
  - If you click on the trigger once to display the menu then click on it again, the menu is hidden.

Thanks for dropit.

Neil
