### PR TITLE
Fix 'mouseleave' for vertical Menus

### DIFF
--- a/dropit.js
+++ b/dropit.js
@@ -57,7 +57,7 @@
 
                     // If hover
                     if(settings.action == 'mouseenter'){
-                        $el.on('mouseleave', function(){
+                        $el.on('mouseleave', '.dropit-open', function(){
                             settings.beforeHide.call(this);
                             $(this).removeClass('dropit-open').find(settings.submenuEl).hide();
                             settings.afterHide.call(this);


### PR DESCRIPTION
Added a selector to mouseleave listener, to work with menu's with combination of dropdowns and non dropdowns