### PR TITLE
Avoid page jumps on dropit menu click

### DIFF
--- a/dropit.js
+++ b/dropit.js
@@ -53,6 +53,7 @@
                         settings.beforeHide.call(this);
                         $('.dropit-open').removeClass('dropit-open').find('.dropit-submenu').hide();
                         settings.afterHide.call(this);
+                        e.preventDefault();
                     });
 
                     // If hover


### PR DESCRIPTION
Any time a Dropit menu item is clicked, the page will jump to the top. This patch prevents this by adding preventDefault() to the click event.